### PR TITLE
Fix Tailwind config and CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,8 @@
+@config '../tailwind.config.cjs';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@reference utilities as *;
 
 @layer base {
   :root {
@@ -85,7 +87,9 @@
     @apply scroll-smooth;
   }
   body {
-    @apply bg-background text-foreground overscroll-none;
+    background-color: hsl(var(--background));
+    color: hsl(var(--foreground));
+    @apply overscroll-none;
     /* font-feature-settings: "rlig" 1, "calt" 1; */
     font-synthesis-weight: none;
     text-rendering: optimizeLegibility;
@@ -120,9 +124,14 @@
   }
 
   .step:before {
-    @apply md:absolute w-8 h-8 md:w-9 md:h-9 bg-muted rounded-full font-mono font-medium text-center text-base inline-flex items-center justify-center -indent-px border-4 mr-2 border-background;
-    @apply md:ml-[-50px] md:mt-[-4px];
+    @apply w-8 h-8 bg-muted rounded-full font-mono font-medium text-center text-base inline-flex items-center justify-center -indent-px border-4 mr-2 border-background;
     content: counter(step);
+  }
+
+  @media (min-width: theme('screens.md')) {
+    .step:before {
+      @apply absolute w-9 h-9 ml-[-50px] mt-[-4px];
+    }
   }
 
   .chunk-container {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -5,7 +5,7 @@ const containerQueries = require('@tailwindcss/container-queries')
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: ['class'],
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx,css}'],
   theme: {
     extend: {
       fontFamily: {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,7 @@ import containerQueries from '@tailwindcss/container-queries'
 
 const config: Config = {
   darkMode: ['class'],
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx,css}'],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
- include CSS files in Tailwind content scanning
- adjust application CSS to avoid using variants with `@apply`
- set colors directly on the body and add Tailwind config directives

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aa66acf90832da686b53839cfb4b5