### PR TITLE
Implement login page and auth utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vitejs/plugin-react": "^4.5.2",
         "axios": "^1.5.0",
         "clsx": "^2.1.1",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.45.0",
@@ -11180,6 +11181,15 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vitejs/plugin-react": "^4.5.2",
     "axios": "^1.5.0",
     "clsx": "^2.1.1",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.45.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import { Suspense, lazy } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Layout from './components/layout/Layout';
+import PrivateRoute from './components/PrivateRoute';
 
 const Home = lazy(() => import('./pages/Home'));
-const Login = lazy(() => import('./pages/Login'));
+const Login = lazy(() => import('./pages/LoginPage'));
 const Dashboard = lazy(() => import('./pages/Dashboard'));
 
 export default function App() {
@@ -13,7 +14,10 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route
+            path="/dashboard"
+            element={<PrivateRoute element={<Dashboard />} />}
+          />
         </Routes>
       </Suspense>
     </Layout>

--- a/src/components/PrivateRoute.tsx
+++ b/src/components/PrivateRoute.tsx
@@ -1,0 +1,12 @@
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import { RootState } from '../store';
+
+interface Props {
+  element: JSX.Element;
+}
+
+export default function PrivateRoute({ element }: Props) {
+  const token = useSelector((state: RootState) => state.auth.accessToken);
+  return token ? element : <Navigate to="/login" replace />;
+}

--- a/src/hooks/useApi.ts
+++ b/src/hooks/useApi.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react';
+import axios from '../api/axiosInstance';
+
+export interface UseApiOptions<TRequest, TResponse> {
+  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  url: string;
+  body?: TRequest;
+  onSuccess?: (data: TResponse) => void;
+}
+
+export interface UseApiReturn<TResponse> {
+  exec: () => Promise<void>;
+  data: TResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useApi<TRequest = unknown, TResponse = unknown>(
+  options: UseApiOptions<TRequest, TResponse>
+): UseApiReturn<TResponse> {
+  const [data, setData] = useState<TResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const exec = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await axios.request<TResponse>({
+        method: options.method,
+        url: options.url,
+        data: options.body
+      });
+      setData(response.data);
+      options.onSuccess?.(response.data);
+    } catch (err: any) {
+      const message = err.response?.data?.message || err.message || 'Error';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  }, [options]);
+
+  return { exec, data, loading, error };
+}
+
+export default useApi;

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,62 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from '../store';
+import { login } from '../store/slices/authSlice';
+import { Card, Input, Button } from '../components/ui';
+
+const schema = z.object({
+  email: z.string().email({ message: 'Invalid email address' }),
+  password: z.string().min(6, { message: 'Password must be at least 6 characters' })
+});
+
+type FormData = z.infer<typeof schema>;
+
+export default function LoginPage() {
+  const dispatch = useDispatch<AppDispatch>();
+  const { status, error } = useSelector((state: RootState) => state.auth);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors }
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = (data: FormData) => {
+    dispatch(login(data));
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+      <Card className="w-full max-w-sm">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          {error && (
+            <div className="text-red-600" role="alert">
+              {error}
+            </div>
+          )}
+          <Input
+            label="Email"
+            type="email"
+            {...register('email')}
+            error={errors.email?.message}
+          />
+          <Input
+            label="Password"
+            type="password"
+            {...register('password')}
+            error={errors.password?.message}
+          />
+          <Button
+            type="submit"
+            fullWidth
+            loading={status === 'loading'}
+            disabled={status === 'loading'}
+          >
+            Login
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -1,46 +1,74 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import axios from '../../api/axiosInstance';
 
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
 interface AuthState {
-  user: string | null;
+  user: User | null;
+  accessToken: string | null;
   status: 'idle' | 'loading' | 'failed';
+  error: string | null;
 }
 
 const initialState: AuthState = {
   user: null,
-  status: 'idle'
+  accessToken: null,
+  status: 'idle',
+  error: null
 };
 
-export const login = createAsyncThunk(
-  'auth/login',
-  async (credentials: { email: string; password: string }) => {
-    const response = await axios.post('/login', credentials);
+export const login = createAsyncThunk<
+  { user: User; accessToken: string },
+  { email: string; password: string },
+  { rejectValue: string }
+>('auth/login', async (credentials, { rejectWithValue }) => {
+  try {
+    const response = await axios.post('/api/auth/login', credentials);
     return response.data;
+  } catch (err: any) {
+    const message = err.response?.data?.message || err.message || 'Login failed';
+    return rejectWithValue(message);
   }
-);
+});
 
 const authSlice = createSlice({
   name: 'auth',
   initialState,
   reducers: {
+    setCredentials(
+      state,
+      action: PayloadAction<{ user: User; accessToken: string }>
+    ) {
+      state.user = action.payload.user;
+      state.accessToken = action.payload.accessToken;
+    },
     logout(state) {
       state.user = null;
+      state.accessToken = null;
     }
   },
   extraReducers: (builder) => {
     builder
       .addCase(login.pending, (state) => {
         state.status = 'loading';
+        state.error = null;
       })
       .addCase(login.fulfilled, (state, action) => {
         state.status = 'idle';
         state.user = action.payload.user;
+        state.accessToken = action.payload.accessToken;
       })
-      .addCase(login.rejected, (state) => {
+      .addCase(login.rejected, (state, action) => {
         state.status = 'failed';
+        state.error = action.payload || 'Login failed';
       });
   }
 });
 
-export const { logout } = authSlice.actions;
+export const { setCredentials, logout } = authSlice.actions;
 export default authSlice.reducer;

--- a/src/utils/createUserFromToken.ts
+++ b/src/utils/createUserFromToken.ts
@@ -1,0 +1,24 @@
+import jwtDecode from 'jwt-decode';
+import axios from '../api/axiosInstance';
+import { AppDispatch } from '../store';
+import { setCredentials, User } from '../store/slices/authSlice';
+
+interface TokenPayload {
+  userId: string;
+  role: string;
+  [key: string]: any;
+}
+
+export const createUserFromToken = async (
+  token: string,
+  dispatch: AppDispatch
+) => {
+  const { userId, role } = jwtDecode<TokenPayload>(token);
+  const response = await axios.get<User>('/api/auth/me', {
+    headers: { Authorization: `Bearer ${token}` }
+  });
+  const user = { ...response.data, id: userId, role };
+  dispatch(setCredentials({ user, accessToken: token }));
+};
+
+export default createUserFromToken;


### PR DESCRIPTION
## Summary
- add `jwt-decode` dependency
- create `LoginPage` using Card, Input and Button components
- create custom `useApi` hook
- overhaul `authSlice` with token handling and error state
- add util to build user from JWT
- protect routes using new `PrivateRoute` component
- update app routes to use new login page and private route

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "prettier")*
- `npm test` *(fails: Jest requires ts-node for TypeScript config)*

------
https://chatgpt.com/codex/tasks/task_e_684d3939acd0832d9c684bf22efcabef