### PR TITLE
Ensure login page bypasses layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,17 +9,17 @@ const Dashboard = lazy(() => import('./pages/Dashboard'));
 
 export default function App() {
   return (
-    <Layout>
-      <Suspense fallback={<div>Loading...</div>}>
-        <Routes>
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route path="/login" element={<Login />} />
+        <Route element={<Layout />}>
           <Route path="/" element={<Home />} />
-          <Route path="/login" element={<Login />} />
           <Route
             path="/dashboard"
             element={<PrivateRoute element={<Dashboard />} />}
           />
-        </Routes>
-      </Suspense>
-    </Layout>
+        </Route>
+      </Routes>
+    </Suspense>
   );
 }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,12 +1,9 @@
-import { ReactNode, useState } from 'react';
+import { useState } from 'react';
+import { Outlet } from 'react-router-dom';
 import Header from './Header';
 import Sidebar from './Sidebar';
 
-interface Props {
-  children: ReactNode;
-}
-
-export default function Layout({ children }: Props) {
+export default function Layout() {
   const [open, setOpen] = useState(true);
 
   return (
@@ -14,7 +11,9 @@ export default function Layout({ children }: Props) {
       <Sidebar open={open} onToggle={() => setOpen(!open)} />
       <div className="flex-1 flex flex-col">
         <Header onToggle={() => setOpen(!open)} />
-        <main className="flex-1 p-4 overflow-auto">{children}</main>
+        <main className="flex-1 p-4 overflow-auto">
+          <Outlet />
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- render nested routes inside layout with `<Outlet>`
- wrap non-login pages in layout so login page is independent

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d3b859c40832db9bf93c749a50326