### PR TITLE
Implement auth persistence

### DIFF
--- a/src/__tests__/authPersistence.test.tsx
+++ b/src/__tests__/authPersistence.test.tsx
@@ -1,0 +1,56 @@
+import { configureStore } from '@reduxjs/toolkit';
+import authReducer, { setCredentials, logout } from '../store/slices/authSlice';
+import { Role } from '../constants/roles';
+import createUserFromToken from '../utils/createUserFromToken';
+
+jest.mock('../api/axiosInstance', () => ({
+  __esModule: true,
+  default: { get: jest.fn() }
+}));
+
+jest.mock('jwt-decode', () => ({
+  __esModule: true,
+  default: jest.fn()
+}));
+
+import axios from '../api/axiosInstance';
+import jwtDecode from 'jwt-decode';
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockedJwtDecode = jwtDecode as jest.Mock;
+
+describe('auth persistence', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('persists and hydrates auth state', async () => {
+    const store = configureStore({ reducer: { auth: authReducer } });
+    const user = {
+      id: '1',
+      name: 'Test',
+      email: 'test@example.com',
+      roles: [Role.Admin]
+    };
+
+    store.dispatch(setCredentials({ user, accessToken: 'token123' }));
+
+    expect(localStorage.getItem('accessToken')).toBe('token123');
+    expect(localStorage.getItem('user')).toContain('Test');
+
+    const newStore = configureStore({ reducer: { auth: authReducer } });
+
+    mockedJwtDecode.mockReturnValue({ userId: '1', roles: [Role.Admin] });
+    mockedAxios.get.mockResolvedValue({ data: user });
+
+    await createUserFromToken('token123', newStore.dispatch);
+
+    expect(newStore.getState().auth.user?.name).toBe('Test');
+    expect(newStore.getState().auth.accessToken).toBe('token123');
+
+    newStore.dispatch(logout());
+    expect(localStorage.getItem('accessToken')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+  });
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,13 @@ import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import App from './App';
 import { store } from './store';
+import createUserFromToken from './utils/createUserFromToken';
 import './index.css';
+
+const savedToken = localStorage.getItem('accessToken');
+if (savedToken) {
+  createUserFromToken(savedToken, store.dispatch);
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -27,22 +27,29 @@ export const login = createAsyncThunk<
   { user: User; accessToken: string },
   { email: string; password: string },
   { rejectValue: string }
->('http://localhost:3000/auth/login', async (credentials, { rejectWithValue }) => {
-  try {
-     const loginRes = await axios.post('http://localhost:3000/api/auth/login', credentials);
-    const { accessToken } = loginRes.data;
+>(
+  'http://localhost:3000/auth/login',
+  async (credentials, { rejectWithValue }) => {
+    try {
+      const loginRes = await axios.post(
+        'http://localhost:3000/api/auth/login',
+        credentials
+      );
+      const { accessToken } = loginRes.data;
 
-    const userRes = await axios.get('http://localhost:3000/api/auth/me', {
-      headers: {
-        Authorization: `Bearer ${accessToken}`
-      }
-    });
-    return { user: userRes.data, accessToken };
-  } catch (err: any) {
-    const message = err.loginRes?.data?.message || err.message || 'Login failed';
-    return rejectWithValue(message);
+      const userRes = await axios.get('http://localhost:3000/api/auth/me', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+      return { user: userRes.data, accessToken };
+    } catch (err: any) {
+      const message =
+        err.loginRes?.data?.message || err.message || 'Login failed';
+      return rejectWithValue(message);
+    }
   }
-});
+);
 
 const authSlice = createSlice({
   name: 'auth',
@@ -54,10 +61,14 @@ const authSlice = createSlice({
     ) {
       state.user = action.payload.user;
       state.accessToken = action.payload.accessToken;
+      localStorage.setItem('accessToken', action.payload.accessToken);
+      localStorage.setItem('user', JSON.stringify(action.payload.user));
     },
     logout(state) {
       state.user = null;
       state.accessToken = null;
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('user');
     }
   },
   extraReducers: (builder) => {
@@ -70,6 +81,8 @@ const authSlice = createSlice({
         state.status = 'idle';
         state.user = action.payload.user;
         state.accessToken = action.payload.accessToken;
+        localStorage.setItem('accessToken', action.payload.accessToken);
+        localStorage.setItem('user', JSON.stringify(action.payload.user));
       })
       .addCase(login.rejected, (state, action) => {
         state.status = 'failed';


### PR DESCRIPTION
## Summary
- store credentials in `localStorage`
- load existing token on startup
- clear stored token on logout
- test persistence logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d5262be60832da44e982c373f8239