### PR TITLE
Add Authorization header via Axios interceptor

### DIFF
--- a/src/api/axiosInstance.test.ts
+++ b/src/api/axiosInstance.test.ts
@@ -1,0 +1,37 @@
+import axios from './axiosInstance';
+import { store } from '../store';
+import { setCredentials, logout } from '../store/slices/authSlice';
+
+describe('axiosInstance request interceptor', () => {
+  const originalAdapter = axios.defaults.adapter!;
+
+  afterEach(() => {
+    axios.defaults.adapter = originalAdapter;
+    store.dispatch(logout());
+  });
+
+  test('adds Authorization header when token exists', async () => {
+    const token = 'testtoken';
+    store.dispatch(
+      setCredentials({
+        user: { id: '1', name: 'Test', email: 't@test.com', roles: [] },
+        accessToken: token
+      })
+    );
+
+    let capturedAuth: any = null;
+    axios.defaults.adapter = (config) => {
+      capturedAuth = config.headers?.Authorization;
+      return Promise.resolve({
+        data: null,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config
+      });
+    };
+
+    await axios.get('/foo');
+    expect(capturedAuth).toBe(`Bearer ${token}`);
+  });
+});

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,11 +1,16 @@
 import axios from 'axios';
+import { store } from '../store';
 
 const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL
 });
 
 axiosInstance.interceptors.request.use((config) => {
-  // Add auth token here
+  const token = store.getState().auth.accessToken;
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
   return config;
 });
 


### PR DESCRIPTION
## Summary
- include Redux store in Axios instance
- attach `Authorization` header if access token exists
- unit test to verify header injection

## Testing
- `npx jest --runTestsByPath src/api/axiosInstance.test.ts` *(fails: ts-node required)*

------
https://chatgpt.com/codex/tasks/task_e_684d526db798832d81da0ef42af9b246