### PR TITLE
Update backend URL references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=<your_api_url>
+VITE_API_BASE_URL=https://dcms-portal-be.onrender.com

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ npm install
 ```
 
 Create a `.env` file based on `.env.example` and set your environment variables.
+At minimum, set `VITE_API_BASE_URL` to `https://dcms-portal-be.onrender.com`.
 
 ## Development
 

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -28,16 +28,16 @@ export const login = createAsyncThunk<
   { email: string; password: string },
   { rejectValue: string }
 >(
-  'http://localhost:3000/auth/login',
+  'https://dcms-portal-be.onrender.com/auth/login',
   async (credentials, { rejectWithValue }) => {
     try {
       const loginRes = await axios.post(
-        'http://localhost:3000/api/auth/login',
+        'https://dcms-portal-be.onrender.com/api/auth/login',
         credentials
       );
       const { accessToken } = loginRes.data;
 
-      const userRes = await axios.get('http://localhost:3000/api/auth/me', {
+      const userRes = await axios.get('https://dcms-portal-be.onrender.com/api/auth/me', {
         headers: {
           Authorization: `Bearer ${accessToken}`
         }


### PR DESCRIPTION
## Summary
- update env example with the production backend URL
- document environment variable in README
- update auth slice to use new backend URL

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684ff8131fa8832d966eb502a798e78f