### PR TITLE
Add appointment calendar and persist auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@fullcalendar/daygrid": "^6.1.8",
+        "@fullcalendar/interaction": "^6.1.17",
         "@fullcalendar/react": "^6.1.8",
         "@heroicons/react": "^2.2.0",
         "@hookform/resolvers": "^3.3.1",
@@ -1448,6 +1449,15 @@
       "version": "6.1.17",
       "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.17.tgz",
       "integrity": "sha512-K7m+pd7oVJ9fW4h7CLDdDGJbc9szJ1xDU1DZ2ag+7oOo1aCNLv44CehzkkknM6r8EYlOOhgaelxQpKAI4glj7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@fullcalendar/core": "~6.1.17"
+      }
+    },
+    "node_modules/@fullcalendar/interaction": {
+      "version": "6.1.17",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.17.tgz",
+      "integrity": "sha512-AudvQvgmJP2FU89wpSulUUjeWv24SuyCx8FzH2WIPVaYg+vDGGYarI7K6PcM3TH7B/CyaBjm5Rqw9lXgnwt5YA==",
       "license": "MIT",
       "peerDependencies": {
         "@fullcalendar/core": "~6.1.17"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@fullcalendar/daygrid": "^6.1.8",
+    "@fullcalendar/interaction": "^6.1.17",
     "@fullcalendar/react": "^6.1.8",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^3.3.1",

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -6,7 +6,8 @@ const axiosInstance = axios.create({
 });
 
 axiosInstance.interceptors.request.use((config) => {
-  const token = store.getState().auth.accessToken;
+  const stateToken = store.getState().auth.accessToken;
+  const token = stateToken || localStorage.getItem('accessToken');
   if (token) {
     config.headers = config.headers || {};
     config.headers.Authorization = `Bearer ${token}`;

--- a/src/pages/Appointments.tsx
+++ b/src/pages/Appointments.tsx
@@ -1,5 +1,104 @@
-import PlaceholderPage from './PlaceholderPage';
+import { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import { RootState, AppDispatch } from '../store';
+import {
+  fetchAppointments,
+  createAppointment,
+  updateAppointment,
+  deleteAppointment,
+  Appointment,
+} from '../store/slices/appointmentsSlice';
+import { Modal, Button, Input } from '../components/ui';
+
+const emptyForm: Appointment = {
+  id: '',
+  patientId: '',
+  doctorId: '',
+  startTime: '',
+  endTime: '',
+  notes: '',
+};
 
 export default function Appointments() {
-  return <PlaceholderPage title='Appointments' />;
+  const dispatch = useDispatch<AppDispatch>();
+  const { items } = useSelector((state: RootState) => state.appointments);
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState<Appointment>(emptyForm);
+
+  useEffect(() => {
+    dispatch(fetchAppointments());
+  }, [dispatch]);
+
+  const handleSelect = (arg: any) => {
+    setForm({ ...emptyForm, startTime: arg.startStr, endTime: arg.endStr });
+    setOpen(true);
+  };
+
+  const handleEventClick = (arg: any) => {
+    const appt = items.find((a) => a.id === arg.event.id);
+    if (appt) {
+      setForm(appt);
+      setOpen(true);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setForm((f) => ({ ...f, [name]: value }));
+  };
+
+  const handleSubmit = () => {
+    if (form.id) {
+      dispatch(updateAppointment(form));
+    } else {
+      const { id, ...data } = form;
+      dispatch(createAppointment(data));
+    }
+    setOpen(false);
+  };
+
+  const handleDelete = () => {
+    if (form.id) dispatch(deleteAppointment(form.id));
+    setOpen(false);
+  };
+
+  return (
+    <div className="p-4">
+      <FullCalendar
+        height="auto"
+        plugins={[dayGridPlugin, interactionPlugin]}
+        initialView="dayGridMonth"
+        selectable
+        select={handleSelect}
+        events={items.map((a) => ({
+          id: a.id,
+          title: a.notes || 'Appointment',
+          start: a.startTime,
+          end: a.endTime,
+        }))}
+        eventClick={handleEventClick}
+      />
+      <Modal isOpen={open} onClose={() => setOpen(false)}>
+        <Modal.Header>{form.id ? 'Edit Appointment' : 'New Appointment'}</Modal.Header>
+        <Modal.Body className="space-y-3">
+          <Input label="Patient ID" name="patientId" value={form.patientId} onChange={handleChange} />
+          <Input label="Doctor ID" name="doctorId" value={form.doctorId} onChange={handleChange} />
+          <Input label="Start Time" type="datetime-local" name="startTime" value={form.startTime} onChange={handleChange} />
+          <Input label="End Time" type="datetime-local" name="endTime" value={form.endTime} onChange={handleChange} />
+          <Input label="Notes" name="notes" value={form.notes} onChange={handleChange} />
+        </Modal.Body>
+        <Modal.Footer className="flex justify-end space-x-2">
+          {form.id && (
+            <Button color="error" variant="outlined" onClick={handleDelete}>
+              Delete
+            </Button>
+          )}
+          <Button onClick={handleSubmit}>Save</Button>
+        </Modal.Footer>
+      </Modal>
+    </div>
+  );
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer from './slices/authSlice';
+import appointmentsReducer from './slices/appointmentsSlice';
 
 export const store = configureStore({
   reducer: {
-    auth: authReducer
+    auth: authReducer,
+    appointments: appointmentsReducer
   }
 });
 

--- a/src/store/slices/appointmentsSlice.ts
+++ b/src/store/slices/appointmentsSlice.ts
@@ -1,0 +1,103 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import axios from '../../api/axiosInstance';
+
+export interface Appointment {
+  id: string;
+  patientId: string;
+  doctorId: string;
+  startTime: string;
+  endTime: string;
+  notes?: string;
+}
+
+interface AppointmentsState {
+  items: Appointment[];
+  status: 'idle' | 'loading' | 'failed';
+  error: string | null;
+}
+
+const initialState: AppointmentsState = {
+  items: [],
+  status: 'idle',
+  error: null
+};
+
+export const fetchAppointments = createAsyncThunk<Appointment[], void, { rejectValue: string }>(
+  'appointments/fetch',
+  async (_, { rejectWithValue }) => {
+    try {
+      const res = await axios.get<Appointment[]>('/api/appointments');
+      return res.data;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || err.message);
+    }
+  }
+);
+
+export const createAppointment = createAsyncThunk<Appointment, Omit<Appointment, 'id'>, { rejectValue: string }>(
+  'appointments/create',
+  async (data, { rejectWithValue }) => {
+    try {
+      const res = await axios.post<Appointment>('/api/appointments', data);
+      return res.data;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || err.message);
+    }
+  }
+);
+
+export const updateAppointment = createAsyncThunk<Appointment, Appointment, { rejectValue: string }>(
+  'appointments/update',
+  async (data, { rejectWithValue }) => {
+    try {
+      const res = await axios.put<Appointment>(`/api/appointments/${data.id}`, data);
+      return res.data;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || err.message);
+    }
+  }
+);
+
+export const deleteAppointment = createAsyncThunk<string, string, { rejectValue: string }>(
+  'appointments/delete',
+  async (id, { rejectWithValue }) => {
+    try {
+      await axios.delete(`/api/appointments/${id}`);
+      return id;
+    } catch (err: any) {
+      return rejectWithValue(err.response?.data?.message || err.message);
+    }
+  }
+);
+
+const appointmentsSlice = createSlice({
+  name: 'appointments',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(fetchAppointments.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(fetchAppointments.fulfilled, (state, action: PayloadAction<Appointment[]>) => {
+        state.status = 'idle';
+        state.items = action.payload;
+      })
+      .addCase(fetchAppointments.rejected, (state, action) => {
+        state.status = 'failed';
+        state.error = action.payload || 'Failed to load appointments';
+      })
+      .addCase(createAppointment.fulfilled, (state, action: PayloadAction<Appointment>) => {
+        state.items.push(action.payload);
+      })
+      .addCase(updateAppointment.fulfilled, (state, action: PayloadAction<Appointment>) => {
+        const idx = state.items.findIndex((a) => a.id === action.payload.id);
+        if (idx >= 0) state.items[idx] = action.payload;
+      })
+      .addCase(deleteAppointment.fulfilled, (state, action: PayloadAction<string>) => {
+        state.items = state.items.filter((a) => a.id !== action.payload);
+      });
+  }
+});
+
+export default appointmentsSlice.reducer;

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -16,9 +16,11 @@ interface AuthState {
   error: string | null;
 }
 
+const storedUser = localStorage.getItem('user');
+const storedToken = localStorage.getItem('accessToken');
 const initialState: AuthState = {
-  user: null,
-  accessToken: null,
+  user: storedUser ? (JSON.parse(storedUser) as User) : null,
+  accessToken: storedToken,
   status: 'idle',
   error: null
 };


### PR DESCRIPTION
## Summary
- persist auth token in store & axios instance
- manage appointments in redux
- add appointment calendar with CRUD actions
- include FullCalendar interaction plugin

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685003fd6f4c832db324988372671359